### PR TITLE
Really fixed path bug on store

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -57,16 +57,15 @@ var updatePath = function (helpers, path, cb) {
   // Run the update
   cb(destination, helpers, traverse);
 
-  // Get ready for new traversal to freeze all
-  // paths
+  // Get ready for new traversal to freeze all paths
   destination = newStore;
   path.forEach(function (pathKey) {
     destination = destination[pathKey];
     Object.freeze(destination);
+    helpers.currentPath.pop();
   });
 
   // Make ready a new store and freeze it
-      helpers.currentPath.pop();
   var store = StoreObject(newStore, helpers);
   Object.keys(newStore).forEach(function (key) {
     Object.defineProperty(store, key, {

--- a/test/immutable-store.js
+++ b/test/immutable-store.js
@@ -293,3 +293,31 @@ exports['the path to a store should be empty'] = function (test) {
   test.equal(store.__.path.length, 0);
   test.done();
 };
+
+exports['the path to a store should be empty after deep set'] = function (test) {
+  var store = new Store({
+    foo: {
+      bar: {
+        foo: 'bar'
+      }
+    }
+  });
+  test.equal(store.__.path.length, 0);
+  var store = store.foo.bar.set('test', 123);
+  test.equal(store.__.path.length, 0);
+  test.done();
+};
+
+exports['the path to a store should be empty after deep merge'] = function (test) {
+  var store = new Store({
+    foo: {
+      bar: {
+        foo: 'bar'
+      }
+    }
+  });
+  test.equal(store.__.path.length, 0);
+  var store = store.foo.bar.merge({test: 123});
+  test.equal(store.__.path.length, 0);
+  test.done();
+};


### PR DESCRIPTION
Your commit at @c8ae27e99ff8d2e1e46b4beede8839012e34f99f didn't fix the problem completely. After a deep investigation I've found the problem: `helpers.currentPath.push() / helpers.currentPath.pop()` counts aren't synced. Therefore single `helpers.currentPath.pop()` didn't help. Added tests proves this.

At https://github.com/christianalfoni/immutable-store/blob/c8ae27e99ff8d2e1e46b4beede8839012e34f99f/src/Store.js#L52 we pushing each `path` segments. So then we should pop each segment at https://github.com/christianalfoni/immutable-store/blob/c8ae27e99ff8d2e1e46b4beede8839012e34f99f/src/Store.js#L66

So my fix does just that.