### PR TITLE
Add unset method to objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,10 +335,12 @@ store = store.array.shift();
 store.array.toJS(); // [] - plain array
 
 store = store.object.set('foo', 'bar');
+store = store.object.unset('foo');
 store = store.object.merge({foo: 'overridenBar'});
 store.object.toJS(); // {foo: 'overridenBar'} - plain object
 
 store = store.set('primitive', 'bar');
+store = store.unset('primitive');
 ```
 
 ## Performance

--- a/src/StoreObject.js
+++ b/src/StoreObject.js
@@ -34,6 +34,11 @@ var StoreObject = function () {
           helpers.currentPath.pop();
         });
       });
+    },
+    unset: function(key) {
+      return this.__.update(this.__.path, function (obj) {
+        delete obj[key];
+      });
     }
   };
 

--- a/test/immutable-store.js
+++ b/test/immutable-store.js
@@ -276,6 +276,40 @@ exports['should throw when trying to merge a non object'] = function (test) {
   test.done();
 };
 
+exports['UNSET should delete a primitive'] = function (test) {
+  var store = new Store({
+    foo: 'foo',
+    bar: 'bar'
+  });
+  var store = store.unset('foo');
+  test.ok(!store.hasOwnProperty('foo'));
+  test.equal(store.bar, 'bar');
+  test.done();
+};
+
+exports['UNSET should delete a key from an object'] = function (test) {
+  var store = new Store({
+    foo: {
+      fiz: [1],
+      bar: [2]
+    },
+  });
+  var store = store.foo.unset('fiz');
+  test.ok(store.hasOwnProperty('foo'));
+  test.ok(!store.foo.hasOwnProperty('fiz'));
+  test.deepEqual(store.foo.bar, [2]);
+  test.done();
+};
+
+exports['UNSET should do nothing if the key does not exist on an object'] = function (test) {
+  var store = new Store({
+    bar: [2]
+  });
+  var store = store.unset('foo');
+  test.deepEqual(store.bar, [2]);
+  test.done();
+};
+
 exports['should work with number primitives in array'] = function (test) {
   var store = new Store({
     items: [0]


### PR DESCRIPTION
`unset` will remove a key from an object and update paths. If the key
does not exist it will do nothing.

Fixes #10