### PR TITLE
Adding IE10 compatibility

### DIFF
--- a/src/StoreArray.js
+++ b/src/StoreArray.js
@@ -5,9 +5,18 @@ var StoreArray = function () {
   function StoreArray(items) {
     var inst = Array.apply(Array);
     inst = inst.concat(items);
-    inst.__proto__ = StoreArray.prototype;
-    return inst;
+    return injectClassMethods(inst);
   }
+
+  function injectClassMethods(collection) {
+        for (var method in StoreArray.prototype) {
+            if (StoreArray.prototype.hasOwnProperty(method)){
+                collection[method] = StoreArray.prototype[method];
+            }
+        }
+        return collection;
+  };
+
   StoreArray.prototype = Object.create(Array.prototype);
   StoreArray.prototype.push = function (item) {
     return this.__.update(this, function (obj, helpers, traverse) {


### PR DESCRIPTION
IE prior to 11 doesn't support `__proto__`. I like this library, but for our purposes we need to at least support IE10 users. This PR adds a function to manually set each method on `StoreArray` rather than assigning a new `__proto__` directly.
